### PR TITLE
Fixed Capabilities for SimpleSAMLphp 2.0.0-beta.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=7.2",
         "simplesamlphp/composer-module-installer": "~1.0",
-        "simplesamlphp/simplesamlphp": "dev-master",
+        "simplesamlphp/simplesamlphp": "^2.0.0-beta.2",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=7.2",
         "simplesamlphp/composer-module-installer": "~1.0",
-        "simplesamlphp/simplesamlphp": "^2.0.0-beta.2",
+        "simplesamlphp/simplesamlphp": "dev-master",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/lib/Auth/Source/Discourse.php
+++ b/lib/Auth/Source/Discourse.php
@@ -102,9 +102,8 @@ class Discourse extends Auth\Source
         $discourseSsoUrl = $this->url . "/session/sso_provider?$query";
 
         // Redirect user to Discourse SSO
-	$httpUtils = new Utils\HTTP();
-	$httpUtils->redirectTrustedURL($discourseSsoUrl);
-	
+        $httpUtils = new Utils\HTTP();
+        $httpUtils->redirectTrustedURL($discourseSsoUrl);
     }
 
 

--- a/lib/Auth/Source/Discourse.php
+++ b/lib/Auth/Source/Discourse.php
@@ -70,7 +70,7 @@ class Discourse extends Auth\Source
      * @param array &$state  Information about the current authentication.
      * @return void
      */
-    public function authenticate(&$state)
+    public function authenticate(array &$state): void
     {
         assert(is_array($state));
 
@@ -102,7 +102,9 @@ class Discourse extends Auth\Source
         $discourseSsoUrl = $this->url . "/session/sso_provider?$query";
 
         // Redirect user to Discourse SSO
-        Utils\HTTP::redirectTrustedURL($discourseSsoUrl);
+	$httpUtils = new Utils\HTTP();
+	$httpUtils->redirectTrustedURL($discourseSsoUrl);
+	
     }
 
 


### PR DESCRIPTION
In php8.0 and  SimpleSAMLphp 2.0.0-beta.2 it will says that Non-static method self::getModuleById() cannot be called statically. I fix this problem.